### PR TITLE
Fix Domain of True Monarchs vs Tribute Summoned Fusion Materials

### DIFF
--- a/script/c84171830.lua
+++ b/script/c84171830.lua
@@ -1,0 +1,95 @@
+--真帝王領域
+local s,id=GetID()
+function s.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--cannot spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e2:SetRange(LOCATION_FZONE)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetTargetRange(0,1)
+	e2:SetCondition(s.discon)
+	e2:SetTarget(s.splimit)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_LEAVE_FIELD_P)
+	e3:SetRange(LOCATION_FZONE)
+	e3:SetCondition(s.effcon)
+	e3:SetOperation(s.effop2)
+	c:RegisterEffect(e3)
+	--atk
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetCode(EFFECT_UPDATE_ATTACK)
+	e4:SetRange(LOCATION_FZONE)
+	e4:SetTargetRange(LOCATION_MZONE,0)
+	e4:SetCondition(s.atkcon)
+	e4:SetTarget(s.atktg)
+	e4:SetValue(800)
+	c:RegisterEffect(e4)
+	--lv
+	local e5=Effect.CreateEffect(c)
+	e5:SetDescription(aux.Stringid(id,0))
+	e5:SetType(EFFECT_TYPE_IGNITION)
+	e5:SetRange(LOCATION_FZONE)
+	e5:SetCountLimit(1)
+	e5:SetTarget(s.lvtg)
+	e5:SetOperation(s.lvop)
+	c:RegisterEffect(e5)
+end
+function s.splimit(e,c)
+	if e:GetHandler():GetFlagEffect(id)>0 then e:GetHandler():ResetFlagEffect(id) return false end
+	return c:IsLocation(LOCATION_EXTRA)
+end
+function s.cfilter(c)
+	return c:IsSummonType(SUMMON_TYPE_ADVANCE)
+end
+function s.discon(e)
+	local tp=e:GetHandlerPlayer()
+	return Duel.GetFieldGroupCount(tp,LOCATION_EXTRA,0)==0
+		and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil)
+		and not Duel.IsExistingMatchingCard(s.cfilter,tp,0,LOCATION_MZONE,1,nil)
+end
+function s.atkcon(e)
+	local d=Duel.GetAttackTarget()
+	local tp=e:GetHandlerPlayer()
+	return Duel.GetCurrentPhase()==PHASE_DAMAGE_CAL and d and d:IsControler(1-tp)
+end
+function s.atktg(e,c)
+	return c==Duel.GetAttacker() and c:IsSummonType(SUMMON_TYPE_ADVANCE)
+end
+function s.filter(c)
+	return c:GetAttack()==2800 and c:GetDefense()==1000
+end
+function s.lvtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_HAND,0,1,nil) end
+end
+function s.lvop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(id,1))
+	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.ConfirmCards(1-tp,g)
+		Duel.ShuffleHand(tp)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_LEVEL)
+		e1:SetValue(-2)
+		e1:SetReset(RESET_EVENT+0xfe0000+RESET_PHASE+PHASE_END)
+		g:GetFirst():RegisterEffect(e1)
+	end
+end
+function s.effcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg and eg:IsExists(function(c) return c:IsSummonType(SUMMON_TYPE_ADVANCE)
+		and c:IsReason(REASON_FUSION) end,1,nil)
+end
+function s.effop2(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(id,0,0,0)
+end


### PR DESCRIPTION
Now the interaction is correct to ruling, in which Domain does not prevent you from finishing your Fusion Summon after you sent your only Tribute Summoned monster(s) as materials. (Domain made you send Fusion Materials without Fusion Summoning the monster before this fix.)